### PR TITLE
change le type de la variable de filtration de int vers double et ajo…

### DIFF
--- a/include/WMLiftingColumnHardwareInterface.h
+++ b/include/WMLiftingColumnHardwareInterface.h
@@ -55,7 +55,7 @@ namespace wm_lifting_column_hardware_interface
         int mResolution;
         double posBuffer;
         int mBumperTimeCounter;
-        int mFilteredCmd;
+        double mFilteredCmd;
     };
 }
 #endif //PROJECT_WMLiftingColumnHardwareInterface_H

--- a/src/WMLiftingColumnHardwareInterface.cpp
+++ b/src/WMLiftingColumnHardwareInterface.cpp
@@ -114,7 +114,7 @@ namespace wm_lifting_column_hardware_interface {
 
         // Send the mFilteredCmd
         std_msgs::Int32 msg;
-        msg.data = mFilteredCmd;
+        msg.data = int(mFilteredCmd);
         CtrlPub.publish( msg );
     }
 


### PR DESCRIPTION
…ute une convertion implicite vers msg.data.

Cela pour fix un bug avec le poignet qui interfèrait pour une raison toujours inconue.
